### PR TITLE
IS-0001: Enable the client_id for the subscription endpoint

### DIFF
--- a/tap_marketingcloud/schemas/definitions.json
+++ b/tap_marketingcloud/schemas/definitions.json
@@ -1,41 +1,45 @@
 {
-    "CUSTOM_PROPERTY_LIST": {
-        "type": "array",
-        "description": "Specifies key-value pairs of properties associated with an object.",
-        "items": {
-            "type": "object",
-            "properties": {
-                "Name": {"type": ["null", "string"]},
-                "Value": {"type": ["null", "string"]}
-            }
-        }
-    },
-    "ID_FIELD": {
-        "type": ["null", "integer"],
-        "description": "Read-only legacy identifier for an object. Not supported on all objects. Some objects use the ObjectID property as the Marketing Cloud unique ID."
-    },
-    "CREATED_DATE_FIELD": {
-        "type": ["null", "string"],
-        "description": "Read-only date and time of the object's creation."
-    },
-    "MODIFIED_DATE_FIELD": {
-        "type": ["null", "string"],
-        "description": "Indicates the last time object information was modified."
-    },
-    "CUSTOMER_KEY_FIELD": {
-        "type": ["null", "string"],
-        "description": "User-supplied unique identifier for an object within an object type (corresponds to the external key assigned to an object in the user interface)."
-    },
-    "OBJECT_ID_FIELD": {
-        "type": ["null", "string"],
-        "description": "System-controlled, read-only text string identifier for object."
-    },
-    "DESCRIPTION_FIELD": {
-        "type": ["null", "string"],
-        "description": "Describes and provides information regarding the object."
-    },
-    "SUBSCRIBER_KEY_FIELD": {
-        "type": ["null", "string"],
-        "description": "Identification of a specific subscriber."
+  "CUSTOM_PROPERTY_LIST": {
+    "type": "array",
+    "description": "Specifies key-value pairs of properties associated with an object.",
+    "items": {
+      "type": "object",
+      "properties": {
+        "Name": { "type": ["null", "string"] },
+        "Value": { "type": ["null", "string"] }
+      }
     }
+  },
+  "CLIENT_ID": {
+    "type": ["null", "string"],
+    "description": "Specifies the account ownership and context of an object."
+  },
+  "ID_FIELD": {
+    "type": ["null", "integer"],
+    "description": "Read-only legacy identifier for an object. Not supported on all objects. Some objects use the ObjectID property as the Marketing Cloud unique ID."
+  },
+  "CREATED_DATE_FIELD": {
+    "type": ["null", "string"],
+    "description": "Read-only date and time of the object's creation."
+  },
+  "MODIFIED_DATE_FIELD": {
+    "type": ["null", "string"],
+    "description": "Indicates the last time object information was modified."
+  },
+  "CUSTOMER_KEY_FIELD": {
+    "type": ["null", "string"],
+    "description": "User-supplied unique identifier for an object within an object type (corresponds to the external key assigned to an object in the user interface)."
+  },
+  "OBJECT_ID_FIELD": {
+    "type": ["null", "string"],
+    "description": "System-controlled, read-only text string identifier for object."
+  },
+  "DESCRIPTION_FIELD": {
+    "type": ["null", "string"],
+    "description": "Describes and provides information regarding the object."
+  },
+  "SUBSCRIBER_KEY_FIELD": {
+    "type": ["null", "string"],
+    "description": "Identification of a specific subscriber."
+  }
 }

--- a/tap_marketingcloud/schemas/subscribers.json
+++ b/tap_marketingcloud/schemas/subscribers.json
@@ -1,36 +1,39 @@
 {
-    "type": "object",
-    "properties": {
-        "Attributes": {
-            "$ref": "definitions.json#/CUSTOM_PROPERTY_LIST"
-        },
-        "CreatedDate": {
-            "$ref": "definitions.json#/CREATED_DATE_FIELD"
-        },
-        "EmailAddress": {
-            "type": ["null", "string"],
-            "description": "Contains the email address for a subscriber. Indicates the data extension field contains email address data."
-        },
-        "EmailTypePreference": {
-            "type": ["null", "string"],
-            "description": "The format in which email should be sent"
-        },
-        "ID": {
-            "$ref": "definitions.json#/ID_FIELD"
-        },
-        "Status": {
-            "type": ["null", "string"],
-            "description": "Defines status of object. Status of an address."
-        },
-        "SubscriberKey": {
-            "$ref": "definitions.json#/SUBSCRIBER_KEY_FIELD"
-        },
-        "UnsubscribedDate": {
-            "type": ["null", "string"],
-            "description": "Represents date subscriber unsubscribed from a list."
-        },
-        "ModifiedDate": {
-            "type": ["null", "string"]
-        }
+  "type": "object",
+  "properties": {
+    "Attributes": {
+      "$ref": "definitions.json#/CUSTOM_PROPERTY_LIST"
+    },
+    "CreatedDate": {
+      "$ref": "definitions.json#/CREATED_DATE_FIELD"
+    },
+    "EmailAddress": {
+      "type": ["null", "string"],
+      "description": "Contains the email address for a subscriber. Indicates the data extension field contains email address data."
+    },
+    "EmailTypePreference": {
+      "type": ["null", "string"],
+      "description": "The format in which email should be sent"
+    },
+    "Client": {
+      "$ref": "definitions.json#/CLIENT_ID"
+    },
+    "ID": {
+      "$ref": "definitions.json#/ID_FIELD"
+    },
+    "Status": {
+      "type": ["null", "string"],
+      "description": "Defines status of object. Status of an address."
+    },
+    "SubscriberKey": {
+      "$ref": "definitions.json#/SUBSCRIBER_KEY_FIELD"
+    },
+    "UnsubscribedDate": {
+      "type": ["null", "string"],
+      "description": "Represents date subscriber unsubscribed from a list."
+    },
+    "ModifiedDate": {
+      "type": ["null", "string"]
     }
+  }
 }


### PR DESCRIPTION
Martech doesn't provide enough detail on subscribers. This edits the meltano tap to include the `client` which is needed to identify them between "Alo", "Bella" and "Moves".